### PR TITLE
Fix Fortran compilation issues

### DIFF
--- a/mylib.f
+++ b/mylib.f
@@ -1,9 +1,10 @@
 module mymodule
+  use iso_c_binding
   implicit none
 contains
   subroutine add_numbers(a, b, result)
-    integer, intent(in) :: a, b
-    integer, intent(out) :: result
+    real(c_float), intent(in) :: a, b
+    real(c_float), intent(out) :: result
     result = a + b
   end subroutine add_numbers
 end module mymodule


### PR DESCRIPTION
Update `mylib.f` to use `real(c_float)` type for `add_numbers` subroutine parameters.

* Add `use iso_c_binding` statement to the `mylib.f` file
* Change `add_numbers` subroutine parameters from `integer` to `real(c_float)`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shams3049/Fortrain-DLL-Example/pull/3?shareId=adc60876-50d6-4bcc-9f3c-388e0f297ac7).